### PR TITLE
docs: add warning about not adding package.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,12 @@ git merge upstream/main
 
 **8.** Stage your changes and commit:
 
+⚠️ **Make sure** if there are no changes in package-related stuff not to commit `package.json` or `package-lock.json` file.
+
+⚠️ **Make sure** not to run the commands `git add .` or `git add *`. Instead, stage your changes for each file/folder.
+
 ```bash
-git add .
+git add <your file/folder changes>
 ```
 
 ```bash


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

Closes #1 

## Changes proposed

Added two warnings to not commit `package.json` and `package-lock.json` files. Also changed the `git add .` command to only stage the changes for each file/folder.

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## Screenshots

![image](https://user-images.githubusercontent.com/74750414/151390065-eaebd5e8-b96c-4b6f-a942-ed6c8edd122b.png)